### PR TITLE
Iterable is in collections.abc

### DIFF
--- a/venn.py
+++ b/venn.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 from itertools import chain
-from collections import Iterable
+from collections.abc import Iterable
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
 from matplotlib import colors


### PR DESCRIPTION
Hi Steve!

As of 3.3 the abstract base classes in `collections` have been moved to `collections.abc`, and their aliases in `collections` are being deprecated. This change supports Python from 3.3 to 3.11 and beyond.

Thanks!